### PR TITLE
docs: Fix simple typo, suppport -> support

### DIFF
--- a/voix.js
+++ b/voix.js
@@ -190,13 +190,13 @@
     /**
      * Expose Voix
      */
-    // AMD suppport
+    // AMD support
     if (typeof window.define === 'function' && window.define.amd !== undefined) {
         window.define('Voix', [], function () {
             return Voix;
         });
 
-    // CommonJS suppport
+    // CommonJS support
     } else if (typeof module !== 'undefined' && module.exports !== undefined) {
         module.exports = Voix;
 


### PR DESCRIPTION
There is a small typo in voix.js.

Should read `support` rather than `suppport`.

